### PR TITLE
Add a resume feature 

### DIFF
--- a/bin/checkm2
+++ b/bin/checkm2
@@ -92,6 +92,7 @@ if __name__ == '__main__':
                                    help='Extension of input files. [Default: .fna]', default='.fna')
 
     predict_arguments.add_argument('--force', action='store_true', help='overwrite output directory [default: not set]', default=False)
+    predict_arguments.add_argument('--resume', action='store_true', help='Reuse Prodigal and DIAMOND results found in output directory [default: not set]', default=False)
     predict_arguments.add_argument('--threads', '-t', type=int, metavar='num_threads', help='number of CPUS to use [default: %i]' % num_threads, default=num_threads)
     predict_arguments.add_argument('--stdout', action='store_true', help='Print results to stdout [default: write to file]', default=False)
     predict_arguments.add_argument('--dbg_cos', action='store_true', help="DEBUG: write cosing similarity values to file [default: don't]", default=False)
@@ -150,8 +151,10 @@ if __name__ == '__main__':
         mode = validate_args_model_choice(args)
         logging.info("Running quality prediction workflow with {} threads.".format(args.threads))
         if len(args.input) == 1 and os.path.isdir(args.input[0]):
-                predictor = predictQuality.Predictor(args.input[0], args.output_directory, args.extension, args.threads, args.force, args.lowmem)
-                predictor.prediction_wf(args.genes, mode, args.dbg_cos, args.dbg_vectors, args.stdout)
+                predictor = predictQuality.Predictor(args.input[0], args.output_directory, args.extension, args.threads,
+                                                     args.force, args.lowmem, args.resume)
+                
+                predictor.prediction_wf(args.genes, mode, args.dbg_cos, args.dbg_vectors, args.stdout, args.resume)
         else:
             if args.genes:
                 bin_extension = 'faa'
@@ -181,8 +184,8 @@ if __name__ == '__main__':
                 else:
                     shutil.copyfile(bin, os.path.join(bin_temporary_dir.name, '{}.{}'.format(os.path.splitext(os.path.basename(bin))[0], bin_extension)))
             predictor = predictQuality.Predictor(bin_temporary_dir.name, args.output_directory, bin_extension, args.threads,
-                                                 args.force, args.lowmem)
-            predictor.prediction_wf(args.genes, mode, args.dbg_cos, args.dbg_vectors, args.stdout)
+                                                 args.force, args.lowmem, args.resume)
+            predictor.prediction_wf(args.genes, mode, args.dbg_cos, args.dbg_vectors, args.stdout, args.resume)
             bin_temporary_dir.cleanup()
 
     elif args.subparser_name == 'testrun':


### PR DESCRIPTION
Hello, 
This PR adds the resume function discussed in issue #13. 

When the flag  `--resume` is used, checkm2 expects to find prodigal and diamond outputs in the output directory and reuses them to make its prediction.  When it does not found the expected files, it returned an error. 

When using the resume flag, the result file misses the column `Translation_Table_Used` as this information is computed on the fly when prodigal is launched by checkm2. This also happens  when the `--genes` flag is used. 

